### PR TITLE
Link to provided sysv init scripts

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -2,6 +2,7 @@
 cfme_dir: /var/www/miq
 vmdb_dir: $cfme_dir/vmdb
 httpd_confd_dir: /etc/httpd/conf.d
+sysv_init_dir: /etc/rc.d/init.d
 
 # cfme_install variables
 github_token:

--- a/tasks/cfme_setup.yml
+++ b/tasks/cfme_setup.yml
@@ -119,6 +119,18 @@
   when: with_httpd
 
 #
+# Link to sysV init script
+#
+
+- name: cfme_init | install sysvinit script {{item}}
+  file: src={{cfme_dir}}/system/LINK/etc/init.d/{{item}}dest={{sysv_init_dir}}/{{item}}
+        owner=root group=root state=link
+  with_items:
+    - evminit
+    - evmserverd
+    - miqtop
+
+#
 # Start application
 #
 
@@ -126,3 +138,7 @@
 #  shell: RBENV_ROOT=${rbenv_root} bundle exec rake evm:start
 #         chdir=$vmdb_dir
 #         creates=$vmdb_dir/tmp/pids/evm.pid
+#
+#- name: cfme_init | service evmserverd start
+#  service: name=evmserverd enabled=yes state=started
+


### PR DESCRIPTION
Create symlinks to the evminit, evmserverd and miqtop initscripts.
These are the same scripts used in packaging CFME, and work with a
git-based deployment if BASEDIR=/var/www/miq/vmdb.  The initscripts
should support a local configuration file (ala
/etc/sysconfig/evmserverd) to allow variable customization.  That should
be tracked upstream against cfme.
